### PR TITLE
14 get scope tree exclude param

### DIFF
--- a/modelservice/games/scopes/base.py
+++ b/modelservice/games/scopes/base.py
@@ -295,7 +295,7 @@ class WampScope(ScopeMixin, SessionScope):
         """
         return self.pubsub_export()
 
-    def _scope_tree(self, *args, **kwargs):
+    def _scope_tree(self, exclude=None, *args, **kwargs):
         """
         Returns this scope and its children serialized.
         """
@@ -308,19 +308,24 @@ class WampScope(ScopeMixin, SessionScope):
                 '_scope_tree: resource_name: {name}, user: {user!s}',
                 name=resource_name, user=user)
 
-            children = scope_group.for_user(user)
+            if resource_name == exclude:
+                self.log.info(
+                    '_scope_tree: exclude {name} children', name=resource_name)
+            else:
+                children = scope_group.for_user(user)
 
-            self.log.debug('_scope_tree: children: {children!s}',
-                           children=children)
+                self.log.debug('_scope_tree: children: {children!s}',
+                               children=children)
 
-            payload['children'] += [child._scope_tree(*args, **kwargs) for
-                                    child in children]
+                payload['children'] += \
+                    [child._scope_tree(exclude, *args, **kwargs)
+                     for child in children]
         return payload
 
     @register
-    def get_scope_tree(self, *args, **kwargs):
-        self.log.debug('get_scope_tree: {name} pk: {pk}',
-                       name=self.resource_name, pk=self.pk)
+    def get_scope_tree(self, exclude=None, *args, **kwargs):
+        self.log.debug('get_scope_tree: {name} pk: {pk} exclude: {exclude}',
+                       name=self.resource_name, pk=self.pk, exclude=exclude)
 
         return self._scope_tree(*args, **kwargs)
 

--- a/modelservice/games/scopes/base.py
+++ b/modelservice/games/scopes/base.py
@@ -305,10 +305,10 @@ class WampScope(ScopeMixin, SessionScope):
         scope_groups = self.child_scopes
         for resource_name, scope_group in scope_groups.items():
             self.log.debug(
-                '_scope_tree: resource_name: {name}, user: {user!s}, exclude: {exclude}',
+                '_scope_tree: resource_name: {name}, user: {user!s}, exclude: {exclude!s}',
                 name=resource_name, user=user, exclude=exclude)
 
-            if resource_name == exclude:
+            if exclude is not None and resource_name in exclude:
                 self.log.debug(
                     '_scope_tree: exclude {name} children', name=resource_name)
             else:
@@ -323,13 +323,11 @@ class WampScope(ScopeMixin, SessionScope):
         return payload
 
     @register
-    def get_scope_tree(self, *args, **kwargs):
-        exclude = args[0] if len(args) > 0 else None
-
-        self.log.debug('get_scope_tree: {name} pk: {pk} exclude: {exclude}',
+    def get_scope_tree(self, exclude=None, *args, **kwargs):
+        self.log.debug('get_scope_tree: {name} pk: {pk} exclude: {exclude!s}',
                        name=self.resource_name, pk=self.pk, exclude=exclude)
 
-        return self._scope_tree(*args, **kwargs)
+        return self._scope_tree(exclude, *args, **kwargs)
 
     async def _unload_scope_tree(self):
         """

--- a/modelservice/games/scopes/base.py
+++ b/modelservice/games/scopes/base.py
@@ -305,11 +305,11 @@ class WampScope(ScopeMixin, SessionScope):
         scope_groups = self.child_scopes
         for resource_name, scope_group in scope_groups.items():
             self.log.debug(
-                '_scope_tree: resource_name: {name}, user: {user!s}',
-                name=resource_name, user=user)
+                '_scope_tree: resource_name: {name}, user: {user!s}, exclude: {exclude}',
+                name=resource_name, user=user, exclude=exclude)
 
             if resource_name == exclude:
-                self.log.info(
+                self.log.debug(
                     '_scope_tree: exclude {name} children', name=resource_name)
             else:
                 children = scope_group.for_user(user)
@@ -323,7 +323,9 @@ class WampScope(ScopeMixin, SessionScope):
         return payload
 
     @register
-    def get_scope_tree(self, exclude=None, *args, **kwargs):
+    def get_scope_tree(self, *args, **kwargs):
+        exclude = args[0] if len(args) > 0 else None
+
         self.log.debug('get_scope_tree: {name} pk: {pk} exclude: {exclude}',
                        name=self.resource_name, pk=self.pk, exclude=exclude)
 


### PR DESCRIPTION
If a resource_name is passed as an argument, exclude that resource type and its children from the returned data.

This feature is used to implement [simpl-react#14](https://github.com/simplworld/simpl-react/issues/14)