### PR TITLE
Load run data on demand

### DIFF
--- a/modelservice/games/scopes/base.py
+++ b/modelservice/games/scopes/base.py
@@ -416,12 +416,13 @@ class WampScope(ScopeMixin, SessionScope):
         runusers = []
         user = kwargs['user']
         for ru in self.my.get_runusers(user.runuser.leader):
-            payload = {}
-            payload['data'] = ru.json
-            payload['data']['online'] = ru.pk in self.online_runusers
-            payload['pk'] = ru.pk
-            payload['resource_name'] = 'runuser'
-            runusers.append(payload)
+            if not excludePlayers or ru.json.leader is True:
+                payload = {}
+                payload['data'] = ru.json
+                payload['data']['online'] = ru.pk in self.online_runusers
+                payload['pk'] = ru.pk
+                payload['resource_name'] = 'runuser'
+                runusers.append(payload)
         return runusers
 
     def get_initial_json(self):

--- a/modelservice/games/scopes/base.py
+++ b/modelservice/games/scopes/base.py
@@ -412,7 +412,7 @@ class WampScope(ScopeMixin, SessionScope):
         return self.json
 
     @register
-    def get_active_runusers(self, *args, **kwargs):
+    def get_active_runusers(self, excludePlayers=False, *args, **kwargs):
         runusers = []
         user = kwargs['user']
         for ru in self.my.get_runusers(user.runuser.leader):

--- a/modelservice/games/scopes/base.py
+++ b/modelservice/games/scopes/base.py
@@ -416,7 +416,7 @@ class WampScope(ScopeMixin, SessionScope):
         runusers = []
         user = kwargs['user']
         for ru in self.my.get_runusers(user.runuser.leader):
-            if not excludePlayers or ru.json.leader is True:
+            if not excludePlayers or ru.leader is True:
                 payload = {}
                 payload['data'] = ru.json
                 payload['data']['online'] = ru.pk in self.online_runusers

--- a/modelservice/games/scopes/concrete.py
+++ b/modelservice/games/scopes/concrete.py
@@ -262,23 +262,24 @@ class Run(Scope):
                      scope.json)
 
     @register
-    async def get_run_data(self, *args, **kwargs):
+    async def get_run_data(self, includePlayerScenarios=False, *args, **kwargs):
         """
         Returns run's worlds and runusers
         """
-        self.log.info('get_run_data: {name} pk: {pk}', name=self.resource_name, pk=self.pk)
+        self.log.debug('get_run_data: {name} pk: {pk}', name=self.resource_name, pk=self.pk)
 
         data_tree = await self.get_scope_tree(None, *args, **kwargs)
         active_runusers = await self.get_active_runusers(False, *args, **kwargs)
         data_tree['runusers'] = active_runusers
         player_scenarios = []
-        for runuser in self.runusers:
-            if runuser.leader is False:
-                scenarios = [
-                    scope._scope_tree(*args, **kwargs)
-                    for scope in runuser.scenarios
-                ]
-                player_scenarios.extend(scenarios)
+        if includePlayerScenarios is True:
+            for runuser in self.runusers:
+                if runuser.leader is False:
+                    scenarios = [
+                        scope._scope_tree(*args, **kwargs)
+                        for scope in runuser.scenarios
+                    ]
+                    player_scenarios.extend(scenarios)
         data_tree['player_scenarios'] = player_scenarios
         return data_tree
 

--- a/modelservice/games/scopes/concrete.py
+++ b/modelservice/games/scopes/concrete.py
@@ -261,6 +261,20 @@ class Run(Scope):
                      scope.resource_name,
                      scope.json)
 
+    @register
+    async def get_run_data(self, *args, **kwargs):
+        """
+        Returns run's worlds and runusers
+        """
+        self.log.info('get_run_data: {name} pk: {pk}', name=self.resource_name, pk=self.pk)
+
+        data_tree = await self.get_scope_tree(None, *args, **kwargs)
+        runusers = await self.get_active_runusers(False, *args, **kwargs)
+        data = {}
+        data['data_tree'] = data_tree
+        data['runusers'] = runusers
+        return data
+
     def update_pubsub(self):
         """
         Propagate update down to child worlds and runusers, so they

--- a/modelservice/games/scopes/concrete.py
+++ b/modelservice/games/scopes/concrete.py
@@ -270,10 +270,8 @@ class Run(Scope):
 
         data_tree = await self.get_scope_tree(None, *args, **kwargs)
         runusers = await self.get_active_runusers(False, *args, **kwargs)
-        data = {}
-        data['data_tree'] = data_tree
-        data['runusers'] = runusers
-        return data
+        data_tree['runusers'] = runusers
+        return data_tree
 
     def update_pubsub(self):
         """

--- a/modelservice/games/scopes/concrete.py
+++ b/modelservice/games/scopes/concrete.py
@@ -269,8 +269,17 @@ class Run(Scope):
         self.log.info('get_run_data: {name} pk: {pk}', name=self.resource_name, pk=self.pk)
 
         data_tree = await self.get_scope_tree(None, *args, **kwargs)
-        runusers = await self.get_active_runusers(False, *args, **kwargs)
-        data_tree['runusers'] = runusers
+        active_runusers = await self.get_active_runusers(False, *args, **kwargs)
+        data_tree['runusers'] = active_runusers
+        player_scenarios = []
+        for runuser in self.runusers:
+            if runuser.leader is False:
+                scenarios = [
+                    scope._scope_tree(*args, **kwargs)
+                    for scope in runuser.scenarios
+                ]
+                player_scenarios.extend(scenarios)
+        data_tree['player_scenarios'] = player_scenarios
         return data_tree
 
     def update_pubsub(self):


### PR DESCRIPTION
- Adds Run.get_run_data RPC to support loading of run worlds, players, and player scenarios on demand.
- Adds get_active_runusers excludePlayers parameter to support not loading players.